### PR TITLE
Fix missing implementations in Tune app

### DIFF
--- a/Tune/Models/MusicLibrary.swift
+++ b/Tune/Models/MusicLibrary.swift
@@ -21,8 +21,22 @@ class MusicLibrary: ObservableObject {
     private func loadDemoSongs() {
         // Add some demo songs for testing
         songs = [
-            Song(title: "Demo Song 1", artist: "Demo Artist", album: "Demo Album", duration: 180, fileURL: URL(string: "file://demo1.mp3")!, artworkData: <#Data?#>),
-            Song(title: "Demo Song 2", artist: "Another Artist", album: "Another Album", duration: 240, fileURL: URL(string: "file://demo2.mp3")!, artworkData: <#Data?#>)
+            Song(
+                title: "Demo Song 1",
+                artist: "Demo Artist",
+                album: "Demo Album",
+                duration: 180,
+                fileURL: URL(string: "file://demo1.mp3")!,
+                artworkData: nil
+            ),
+            Song(
+                title: "Demo Song 2",
+                artist: "Another Artist",
+                album: "Another Album",
+                duration: 240,
+                fileURL: URL(string: "file://demo2.mp3")!,
+                artworkData: nil
+            )
         ]
     }
 }

--- a/Tune/Models/Playlist.swift
+++ b/Tune/Models/Playlist.swift
@@ -5,3 +5,12 @@
 //  Created by Mfon Udoh on 2025-05-31.
 //
 
+import Foundation
+
+/// A simple collection of songs.
+struct Playlist: Identifiable, Codable, Hashable {
+    var id = UUID()
+    var name: String
+    var songs: [Song]
+}
+

--- a/Tune/Utilities/FileManager+Extensions.swift
+++ b/Tune/Utilities/FileManager+Extensions.swift
@@ -5,3 +5,13 @@
 //  Created by Mfon Udoh on 2025-05-31.
 //
 
+import Foundation
+
+extension FileManager {
+    /// Returns the user's documents directory on iOS or macOS.
+    static var documentsDirectory: URL {
+        `default`.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+}
+
+

--- a/Tune/ViewModels/LibraryViewModel.swift
+++ b/Tune/ViewModels/LibraryViewModel.swift
@@ -5,3 +5,15 @@
 //  Created by Mfon Udoh on 2025-05-31.
 //
 
+import Foundation
+
+/// View model for the library view.
+final class LibraryViewModel: ObservableObject {
+    @Published var library = MusicLibrary.shared
+
+    var songs: [Song] {
+        library.songs
+    }
+}
+
+

--- a/Tune/ViewModels/NowPlayingViewModel.swift
+++ b/Tune/ViewModels/NowPlayingViewModel.swift
@@ -5,3 +5,11 @@
 //  Created by Mfon Udoh on 2025-05-31.
 //
 
+import Foundation
+
+/// Exposes state from `AudioPlayerManager` to the UI.
+final class NowPlayingViewModel: ObservableObject {
+    @Published var player = AudioPlayerManager.shared
+}
+
+

--- a/Tune/ViewModels/PlaylistViewModel.swift
+++ b/Tune/ViewModels/PlaylistViewModel.swift
@@ -5,3 +5,15 @@
 //  Created by Mfon Udoh on 2025-05-31.
 //
 
+import Foundation
+
+/// Manages playlists in the app.
+final class PlaylistViewModel: ObservableObject {
+    @Published var playlists: [Playlist] = []
+
+    func addPlaylist(name: String, songs: [Song] = []) {
+        playlists.append(Playlist(name: name, songs: songs))
+    }
+}
+
+

--- a/Tune/Views/Components/MiniPlayerView.swift
+++ b/Tune/Views/Components/MiniPlayerView.swift
@@ -8,8 +8,33 @@
 import SwiftUI
 
 struct MiniPlayerView: View {
+    @EnvironmentObject var audioPlayer: AudioPlayerManager
+
     var body: some View {
-        // Empty for now - will implement when audio player is ready
-        EmptyView()
+        VStack(spacing: 4) {
+            if let song = audioPlayer.currentSong {
+                HStack {
+                    Text("\(song.title) - \(song.artist)")
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Button(action: audioPlayer.togglePlayPause) {
+                        Image(systemName: audioPlayer.isPlaying ? "pause.fill" : "play.fill")
+                            .padding(.horizontal, 8)
+                    }
+                }
+            } else {
+                Text("No song playing")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(8)
+        .background(.thinMaterial)
     }
+}
+
+#Preview {
+    MiniPlayerView()
+        .environmentObject(AudioPlayerManager.shared)
 }

--- a/Tune/Views/Components/SongRowView.swift
+++ b/Tune/Views/Components/SongRowView.swift
@@ -4,3 +4,41 @@
 //
 //  Created by Mfon Udoh on 2025-05-31.
 //
+
+import SwiftUI
+
+/// A simple row that displays basic song information.
+struct SongRowView: View {
+    let song: Song
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(song.title)
+                    .font(.headline)
+                Text(song.artist)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(song.durationString)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    SongRowView(song: Song(
+        title: "Preview",
+        artist: "Artist",
+        album: nil,
+        duration: 200,
+        fileURL: URL(string: "file://preview.mp3")!,
+        artworkData: nil
+    ))
+}
+

--- a/Tune/Views/LibraryView.swift
+++ b/Tune/Views/LibraryView.swift
@@ -8,11 +8,16 @@ import SwiftUI
 
 struct LibraryView: View {
     @EnvironmentObject var musicLibrary: MusicLibrary
+    @EnvironmentObject var audioPlayer: AudioPlayerManager
     
     var body: some View {
         NavigationView {
             List(musicLibrary.songs) { song in
-                Text("\(song.title) - \(song.artist)")
+                SongRowView(song: song)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        audioPlayer.play(song: song)
+                    }
             }
             .navigationTitle("Library")
         }
@@ -22,4 +27,5 @@ struct LibraryView: View {
 #Preview {
     LibraryView()
         .environmentObject(MusicLibrary.shared)
+        .environmentObject(AudioPlayerManager.shared)
 }

--- a/Tune/Views/NowPlayingView.swift
+++ b/Tune/Views/NowPlayingView.swift
@@ -4,3 +4,38 @@
 //
 //  Created by Mfon Udoh on 2025-05-31.
 //
+
+import SwiftUI
+
+/// Displays details for the currently playing song.
+struct NowPlayingView: View {
+    @EnvironmentObject var audioPlayer: AudioPlayerManager
+
+    var body: some View {
+        VStack {
+            if let song = audioPlayer.currentSong {
+                Text(song.title)
+                    .font(.title)
+                    .padding(.bottom, 1)
+                Text(song.artist)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                PlayerControlsView()
+                    .environmentObject(audioPlayer)
+            } else {
+                Text("Nothing Playing")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    NowPlayingView()
+        .environmentObject(AudioPlayerManager.shared)
+}
+


### PR DESCRIPTION
## Summary
- remove placeholders in demo songs
- implement Playlist model
- add utility for getting the documents directory
- create view models and UI components
- connect library list to playback

## Testing
- `swiftc Tune/**/*.swift Tune/*.swift -o /tmp/tune_app` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6844f808323c832a9d841e7a55579839