### PR TITLE
Add full UI with playlists and now playing sheet

### DIFF
--- a/Tune/ContentView.swift
+++ b/Tune/ContentView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var showNowPlaying = false
+
     var body: some View {
         TabView {
             LibraryView()
@@ -29,7 +31,12 @@ struct ContentView: View {
                 }
         }
         .overlay(alignment: .bottom) {
-            MiniPlayerView()
+            MiniPlayerView {
+                showNowPlaying = true
+            }
+        }
+        .sheet(isPresented: $showNowPlaying) {
+            NowPlayingView()
         }
     }
 }
@@ -38,4 +45,5 @@ struct ContentView: View {
     ContentView()
         .environmentObject(MusicLibrary.shared)
         .environmentObject(AudioPlayerManager.shared)
+        .environmentObject(PlaylistViewModel())
 }

--- a/Tune/TuneApp.swift
+++ b/Tune/TuneApp.swift
@@ -11,12 +11,14 @@ import SwiftUI
 struct TuneApp: App {
     @StateObject private var musicLibrary = MusicLibrary.shared
     @StateObject private var audioPlayer = AudioPlayerManager.shared
+    @StateObject private var playlistViewModel = PlaylistViewModel()
     
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(musicLibrary)
                 .environmentObject(audioPlayer)
+                .environmentObject(playlistViewModel)
         }
     }
 }

--- a/Tune/Views/Components/MiniPlayerView.swift
+++ b/Tune/Views/Components/MiniPlayerView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MiniPlayerView: View {
     @EnvironmentObject var audioPlayer: AudioPlayerManager
+    var onTap: (() -> Void)? = nil
 
     var body: some View {
         VStack(spacing: 4) {
@@ -31,6 +32,9 @@ struct MiniPlayerView: View {
         }
         .padding(8)
         .background(.thinMaterial)
+        .onTapGesture {
+            onTap?()
+        }
     }
 }
 

--- a/Tune/Views/NowPlayingView.swift
+++ b/Tune/Views/NowPlayingView.swift
@@ -21,6 +21,20 @@ struct NowPlayingView: View {
                     .font(.headline)
                     .foregroundStyle(.secondary)
 
+                Slider(value: Binding(
+                    get: { audioPlayer.currentTime },
+                    set: { newValue in
+                        audioPlayer.seekTo(time: newValue)
+                    }
+                ), in: 0...audioPlayer.duration)
+
+                HStack {
+                    Text(formattedTime(audioPlayer.currentTime))
+                    Spacer()
+                    Text(formattedTime(audioPlayer.duration))
+                }
+                .font(.caption)
+
                 Spacer()
 
                 PlayerControlsView()
@@ -31,6 +45,12 @@ struct NowPlayingView: View {
             }
         }
         .padding()
+    }
+
+    private func formattedTime(_ time: TimeInterval) -> String {
+        let minutes = Int(time) / 60
+        let seconds = Int(time) % 60
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 }
 

--- a/Tune/Views/PlaylistDetailView.swift
+++ b/Tune/Views/PlaylistDetailView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct PlaylistDetailView: View {
+    @EnvironmentObject var audioPlayer: AudioPlayerManager
+    let playlist: Playlist
+
+    var body: some View {
+        List(playlist.songs) { song in
+            SongRowView(song: song)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    audioPlayer.play(song: song)
+                }
+        }
+        .navigationTitle(playlist.name)
+    }
+}
+
+#Preview {
+    PlaylistDetailView(playlist: Playlist(name: "Preview", songs: []))
+        .environmentObject(AudioPlayerManager.shared)
+}

--- a/Tune/Views/PlaylistView.swift
+++ b/Tune/Views/PlaylistView.swift
@@ -8,10 +8,51 @@
 import SwiftUI
 
 struct PlaylistView: View {
+    @EnvironmentObject var playlistViewModel: PlaylistViewModel
+    @State private var showCreate = false
+    @State private var newPlaylistName = ""
+
     var body: some View {
         NavigationView {
-            Text("Playlists Coming Soon")
-                .navigationTitle("Playlists")
+            List {
+                ForEach(playlistViewModel.playlists) { playlist in
+                    NavigationLink(destination: PlaylistDetailView(playlist: playlist)) {
+                        Text(playlist.name)
+                    }
+                }
+            }
+            .navigationTitle("Playlists")
+            .toolbar {
+                Button(action: { showCreate = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+            .sheet(isPresented: $showCreate) {
+                NavigationStack {
+                    Form {
+                        TextField("Playlist Name", text: $newPlaylistName)
+                    }
+                    .navigationTitle("New Playlist")
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { showCreate = false }
+                        }
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Add") {
+                                playlistViewModel.addPlaylist(name: newPlaylistName)
+                                newPlaylistName = ""
+                                showCreate = false
+                            }.disabled(newPlaylistName.isEmpty)
+                        }
+                    }
+                }
+            }
         }
     }
+}
+
+#Preview {
+    PlaylistView()
+        .environmentObject(PlaylistViewModel())
+        .environmentObject(AudioPlayerManager.shared)
 }

--- a/Tune/Views/SettingsView.swift
+++ b/Tune/Views/SettingsView.swift
@@ -8,10 +8,16 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @State private var notificationsEnabled = true
+    @State private var cellularDownloads = false
+
     var body: some View {
         NavigationView {
-            Text("Settings Coming Soon")
-                .navigationTitle("Settings")
+            Form {
+                Toggle("Enable Notifications", isOn: $notificationsEnabled)
+                Toggle("Download Over Cellular", isOn: $cellularDownloads)
+            }
+            .navigationTitle("Settings")
         }
     }
 }


### PR DESCRIPTION
## Summary
- enable playlist model in app environment
- add sheet to show `NowPlayingView` from mini player
- tap on mini player to open now playing
- show playback progress and duration in now playing view
- implement playlist management UI and playlist detail screen
- add simple toggles in settings view